### PR TITLE
feat: Add support for the time crate

### DIFF
--- a/docs/book/content/types/scalars.md
+++ b/docs/book/content/types/scalars.md
@@ -6,11 +6,11 @@ but this often requires coordination with the client library intended to consume
 the API you're building.
 
 Since any value going over the wire is eventually transformed into JSON, you're
-also limited in the data types you can use. 
+also limited in the data types you can use.
 
-There are two ways to define custom scalars. 
+There are two ways to define custom scalars.
 * For simple scalars that just wrap a primitive type, you can use the newtype pattern with
-a custom derive. 
+a custom derive.
 * For more advanced use cases with custom validation, you can use
 the `graphql_scalar` proc macro.
 
@@ -36,12 +36,13 @@ crates. They are enabled via features that are on by default.
 
 * uuid::Uuid
 * chrono::DateTime
+* time::{Date, OffsetDateTime, PrimitiveDateTime}
 * url::Url
 * bson::oid::ObjectId
 
 ## newtype pattern
 
-Often, you might need a custom scalar that just wraps an existing type. 
+Often, you might need a custom scalar that just wraps an existing type.
 
 This can be done with the newtype pattern and a custom derive, similar to how
 serde supports this pattern with `#[serde(transparent)]`.
@@ -82,15 +83,15 @@ pub struct UserId(i32);
 
 ## Custom scalars
 
-For more complex situations where you also need custom parsing or validation, 
+For more complex situations where you also need custom parsing or validation,
 you can use the `graphql_scalar` proc macro.
 
 Typically, you represent your custom scalars as strings.
 
 The example below implements a custom scalar for a custom `Date` type.
 
-Note: juniper already has built-in support for the `chrono::DateTime` type 
-via `chrono` feature, which is enabled by default and should be used for this 
+Note: juniper already has built-in support for the `chrono::DateTime` type
+via `chrono` feature, which is enabled by default and should be used for this
 purpose.
 
 The example below is used just for illustration.
@@ -101,9 +102,9 @@ The example below is used just for illustration.
 
 ```rust
 # extern crate juniper;
-# mod date { 
-#    pub struct Date; 
-#    impl std::str::FromStr for Date{ 
+# mod date {
+#    pub struct Date;
+#    impl std::str::FromStr for Date{
 #        type Err = String; fn from_str(_value: &str) -> Result<Self, Self::Err> { unimplemented!() }
 #    }
 #    // And we define how to represent date as a string.
@@ -118,7 +119,7 @@ use juniper::{Value, ParseScalarResult, ParseScalarValue};
 use date::Date;
 
 #[juniper::graphql_scalar(description = "Date")]
-impl<S> GraphQLScalar for Date 
+impl<S> GraphQLScalar for Date
 where
     S: ScalarValue
 {

--- a/juniper/Cargo.toml
+++ b/juniper/Cargo.toml
@@ -22,6 +22,7 @@ travis-ci = { repository = "graphql-rust/juniper" }
 default = [
     "bson",
     "chrono",
+    "time",
     "schema-language",
     "url",
     "uuid",
@@ -39,6 +40,7 @@ async-trait = "0.1.39"
 bson = { version = "2.0", features = ["chrono-0_4"], optional = true }
 chrono = { version = "0.4", default-features = false, optional = true }
 chrono-tz = { version = "0.6", default-features = false, optional = true }
+time = { version = "0.3", features = ["parsing", "formatting"], optional = true }
 fnv = "1.0.3"
 futures = { version = "0.3.1", features = ["alloc"], default-features = false }
 futures-enum = { version = "0.1.12", default-features = false }

--- a/juniper/src/integrations/mod.rs
+++ b/juniper/src/integrations/mod.rs
@@ -8,6 +8,8 @@ pub mod chrono;
 pub mod chrono_tz;
 #[doc(hidden)]
 pub mod serde;
+#[cfg(feature = "time")]
+pub mod time;
 #[cfg(feature = "url")]
 pub mod url;
 #[cfg(feature = "uuid")]

--- a/juniper/src/integrations/time.rs
+++ b/juniper/src/integrations/time.rs
@@ -1,0 +1,338 @@
+/*!
+
+# Supported types
+
+| Rust Type           | JSON Serialization  | Notes                                |
+|---------------------|---------------------|--------------------------------------|
+| `OffsetDateTime`    | RFC3339 string      |                                      |
+| `Date`              | YYYY-MM-DD          |                                      |
+| `PrimitiveDateTime` | YYYY-MM-DD HH-MM-SS |                                      |
+| `Time`              | H:M:S               | Optional. Use the `scalar-naivetime` |
+|                     |                     | feature.                             |
+
+*/
+use time::{
+    format_description::parse, format_description::well_known::Rfc3339, Date, OffsetDateTime,
+    PrimitiveDateTime,
+};
+
+#[cfg(feature = "scalar-naivetime")]
+use time::Time;
+
+use crate::{
+    parser::{ParseError, ScalarToken, Token},
+    value::{ParseScalarResult, ParseScalarValue},
+    Value,
+};
+
+#[doc(hidden)]
+pub static RFC3339_FORMAT: &str = "%Y-%m-%dT%H:%M:%S%.f%:z";
+
+#[crate::graphql_scalar(name = "DateTimeFixedOffset", description = "OffsetDateTime")]
+impl<S> GraphQLScalar for OffsetDateTime
+where
+    S: ScalarValue,
+{
+    fn resolve(&self) -> Value {
+        Value::scalar(
+            self.format(&Rfc3339)
+                .expect("Failed to format `DateTimeFixedOffset`"),
+        )
+    }
+
+    fn from_input_value(v: &InputValue) -> Result<OffsetDateTime, String> {
+        v.as_string_value()
+            .ok_or_else(|| format!("Expected `String`, found: {}", v))
+            .and_then(|s| {
+                time::OffsetDateTime::parse(s, &Rfc3339)
+                    .map_err(|e| format!("Failed to parse `DateTimeFixedOffset`: {}", e))
+            })
+    }
+
+    fn from_str<'a>(value: ScalarToken<'a>) -> ParseScalarResult<'a, S> {
+        if let ScalarToken::String(value) = value {
+            Ok(S::from(value.to_owned()))
+        } else {
+            Err(ParseError::UnexpectedToken(Token::Scalar(value)))
+        }
+    }
+}
+
+#[crate::graphql_scalar(description = "Date")]
+impl<S> GraphQLScalar for Date
+where
+    S: ScalarValue,
+{
+    fn resolve(&self) -> Value {
+        let description =
+            parse("[year]-[month]-[day]").expect("Failed to parse format description");
+        Value::scalar(
+            self.format(&description)
+                .expect("Failed to format `Date`")
+                .to_string(),
+        )
+    }
+
+    fn from_input_value(v: &InputValue) -> Result<Date, String> {
+        v.as_string_value()
+            .ok_or_else(|| format!("Expected `String`, found: {}", v))
+            .and_then(|s| {
+                let description =
+                    parse("[year]-[month]-[day]").expect("Failed to parse format description");
+                Date::parse(s, &description).map_err(|e| format!("Failed to parse `Date`: {}", e))
+            })
+    }
+
+    fn from_str<'a>(value: ScalarToken<'a>) -> ParseScalarResult<'a, S> {
+        if let ScalarToken::String(value) = value {
+            Ok(S::from(value.to_owned()))
+        } else {
+            Err(ParseError::UnexpectedToken(Token::Scalar(value)))
+        }
+    }
+}
+
+#[cfg(feature = "scalar-naivetime")]
+#[crate::graphql_scalar(description = "Time")]
+impl<S> GraphQLScalar for Time
+where
+    S: ScalarValue,
+{
+    fn resolve(&self) -> Value {
+        let description =
+            parse("[hour]:[minute]:[second]").expect("Failed to parse format description");
+        Value::scalar(
+            self.format(&description)
+                .expect("Failed to format `Time`")
+                .to_string(),
+        )
+    }
+
+    fn from_input_value(v: &InputValue) -> Result<Time, String> {
+        v.as_string_value()
+            .ok_or_else(|| format!("Expected `String`, found: {}", v))
+            .and_then(|s| {
+                let description =
+                    parse("[hour]:[minute]:[second]").expect("Failed to parse format description");
+                Time::parse(s, &description).map_err(|e| format!("Failed to parse `Time`: {}", e))
+            })
+    }
+
+    fn from_str<'a>(value: ScalarToken<'a>) -> ParseScalarResult<'a, S> {
+        if let ScalarToken::String(value) = value {
+            Ok(S::from(value.to_owned()))
+        } else {
+            Err(ParseError::UnexpectedToken(Token::Scalar(value)))
+        }
+    }
+}
+
+#[crate::graphql_scalar(description = "PrimitiveDateTime")]
+impl<S> GraphQLScalar for PrimitiveDateTime
+where
+    S: ScalarValue,
+{
+    fn resolve(&self) -> Value {
+        let description = parse("[year]-[month]-[day] [hour]:[minute]:[second]")
+            .expect("Failed to parse format description");
+        Value::scalar(
+            self.format(&description)
+                .expect("Failed to format `PrimitiveDateTime`"),
+        )
+    }
+
+    fn from_input_value(v: &InputValue) -> Result<PrimitiveDateTime, String> {
+        v.as_string_value()
+            .ok_or_else(|| format!("Expected `String`, found: {}", v))
+            .and_then(|s| {
+                let description = parse("[year]-[month]-[day] [hour]:[minute]:[second]")
+                    .expect("Failed to parse format description");
+                PrimitiveDateTime::parse(s, &description)
+                    .map_err(|e| format!("Failed to parse `PrimitiveDateTime`: {}", e))
+            })
+    }
+
+    fn from_str<'a>(value: ScalarToken<'a>) -> ParseScalarResult<'a, S> {
+        <f64 as ParseScalarValue<S>>::from_str(value)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::convert::TryFrom;
+
+    use time::{
+        format_description::parse, format_description::well_known::Rfc3339, Date, Month,
+        OffsetDateTime, PrimitiveDateTime, Time,
+    };
+
+    use crate::{graphql_input_value, FromInputValue, InputValue};
+
+    fn offsetdatetime_test(raw: &'static str) {
+        let input: InputValue = graphql_input_value!((raw));
+
+        let parsed: OffsetDateTime = FromInputValue::from_input_value(&input).unwrap();
+        let expected = OffsetDateTime::parse(raw, &Rfc3339).unwrap();
+
+        assert_eq!(parsed, expected);
+    }
+
+    #[test]
+    fn offsetdatetime_from_input_value() {
+        offsetdatetime_test("2014-11-28T21:00:09+09:00");
+    }
+
+    #[test]
+    fn offsetdatetime_from_input_value_with_z_timezone() {
+        offsetdatetime_test("2014-11-28T21:00:09Z");
+    }
+
+    #[test]
+    fn offsetdatetime_from_input_value_with_fractional_seconds() {
+        offsetdatetime_test("2014-11-28T21:00:09.05+09:00");
+    }
+
+    #[test]
+    fn date_from_input_value() {
+        let y = 1996;
+        let m = 12;
+        let d = 19;
+        let input: InputValue = graphql_input_value!("1996-12-19");
+
+        let parsed: Date = FromInputValue::from_input_value(&input).unwrap();
+        let expected = Date::from_calendar_date(y, Month::try_from(m).unwrap(), d).unwrap();
+
+        assert_eq!(parsed, expected);
+
+        assert_eq!(parsed.year(), y);
+        assert_eq!(u8::from(parsed.month()), m);
+        assert_eq!(parsed.day(), d);
+    }
+
+    #[test]
+    #[cfg(feature = "scalar-naivetime")]
+    fn time_from_input_value() {
+        let input: InputValue = graphql_input_value!("21:12:19");
+        let [h, m, s] = [21, 12, 19];
+        let parsed: Time = FromInputValue::from_input_value(&input).unwrap();
+        let expected = Time::from_hms(h, m, s).unwrap();
+        assert_eq!(parsed, expected);
+        assert_eq!(parsed.hour(), h);
+        assert_eq!(parsed.minute(), m);
+        assert_eq!(parsed.second(), s);
+    }
+
+    #[test]
+    fn primitivedatetime_from_input_value() {
+        let raw = "2021-12-15 14:12:00";
+        let input: InputValue = graphql_input_value!((raw));
+
+        let parsed: PrimitiveDateTime = FromInputValue::from_input_value(&input).unwrap();
+        let description = parse("[year]-[month]-[day] [hour]:[minute]:[second]").unwrap();
+        let expected = PrimitiveDateTime::parse(&raw, &description).unwrap();
+
+        assert_eq!(parsed, expected);
+    }
+}
+
+#[cfg(test)]
+mod integration_test {
+    use time::{
+        format_description::parse, format_description::well_known::Rfc3339, Date, Month,
+        OffsetDateTime, PrimitiveDateTime,
+    };
+
+    #[cfg(feature = "scalar-naivetime")]
+    use time::Time;
+
+    use crate::{
+        graphql_object, graphql_value, graphql_vars,
+        schema::model::RootNode,
+        types::scalars::{EmptyMutation, EmptySubscription},
+    };
+
+    #[tokio::test]
+    async fn test_serialization() {
+        struct Root;
+
+        #[graphql_object]
+        #[cfg(feature = "scalar-naivetime")]
+        impl Root {
+            fn example_date() -> Date {
+                Date::from_calendar_date(2015, Month::March, 14).unwrap()
+            }
+            fn example_primitive_date_time() -> PrimitiveDateTime {
+                let description = parse("[year]-[month]-[day] [hour]:[minute]:[second]").unwrap();
+                PrimitiveDateTime::parse("2016-07-08 09:10:11", &description).unwrap()
+            }
+            fn example_time() -> Time {
+                Time::from_hms(16, 7, 8).unwrap()
+            }
+            fn example_offset_date_time() -> OffsetDateTime {
+                OffsetDateTime::parse("1996-12-19T16:39:57-08:00", &Rfc3339).unwrap()
+            }
+        }
+
+        #[graphql_object]
+        #[cfg(not(feature = "scalar-naivetime"))]
+        impl Root {
+            fn example_date() -> Date {
+                Date::from_calendar_date(2015, Month::March, 14).unwrap()
+            }
+            fn example_primitive_date_time() -> PrimitiveDateTime {
+                let description = parse("[year]-[month]-[day] [hour]:[minute]:[second]").unwrap();
+                PrimitiveDateTime::parse("2016-07-08 09:10:11", &description).unwrap()
+            }
+            fn example_offset_date_time() -> OffsetDateTime {
+                OffsetDateTime::parse("1996-12-19T16:39:57-08:00", &Rfc3339).unwrap()
+            }
+        }
+
+        #[cfg(feature = "scalar-naivetime")]
+        let doc = r#"{
+            exampleDate,
+            examplePrimitiveDateTime,
+            exampleTime,
+            exampleOffsetDateTime,
+        }"#;
+
+        #[cfg(not(feature = "scalar-naivetime"))]
+        let doc = r#"{
+            exampleDate,
+            examplePrimitiveDateTime,
+            exampleOffsetDateTime,
+        }"#;
+
+        let schema = RootNode::new(
+            Root,
+            EmptyMutation::<()>::new(),
+            EmptySubscription::<()>::new(),
+        );
+
+        let (result, errs) = crate::execute(doc, None, &schema, &graphql_vars! {}, &())
+            .await
+            .expect("Execution failed");
+
+        assert_eq!(errs, []);
+
+        #[cfg(feature = "scalar-naivetime")]
+        assert_eq!(
+            result,
+            graphql_value!({
+                "exampleDate": "2015-03-14",
+                "examplePrimitiveDateTime": "2016-07-08 09:10:11",
+                "exampleTime": "16:07:08",
+                "exampleOffsetDateTime": "1996-12-19T16:39:57-08:00",
+            }),
+        );
+        #[cfg(not(feature = "scalar-naivetime"))]
+        assert_eq!(
+            result,
+            graphql_value!({
+                "exampleDate": "2015-03-14",
+                "examplePrimitiveDateTime": "2016-07-08 09:10:11",
+                "exampleOffsetDateTime": "1996-12-19T16:39:57-08:00",
+            }),
+        );
+    }
+}

--- a/juniper/src/lib.rs
+++ b/juniper/src/lib.rs
@@ -59,6 +59,7 @@ your Schemas automatically.
 * [uuid][uuid]
 * [url][url]
 * [chrono][chrono]
+* [time][time]
 * [bson][bson]
 
 ### Web Frameworks
@@ -87,6 +88,7 @@ Juniper has not reached 1.0 yet, thus some API instability should be expected.
 [uuid]: https://crates.io/crates/uuid
 [url]: https://crates.io/crates/url
 [chrono]: https://crates.io/crates/chrono
+[time]: https://crates.io/crates/time
 [bson]: https://crates.io/crates/bson
 
 */


### PR DESCRIPTION
This adds support for the `time` crate due to concerns with safety in the `chrono` crate (see https://github.com/rustsec/advisory-db/pull/1082).

So, I added support for time, since it looks like that might become the "preferred" date/time crate in the future.